### PR TITLE
Feature/json api people

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /backend/config/master.key
+
+# Mac shit
+.DS_Store

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -14,9 +14,13 @@ gem 'pg', '~> 1.1'
 gem 'puma', '~> 5.0'
 gem 'rack-cors'
 gem 'rails', '~> 7.0.4', '>= 7.0.4.2'
-gem 'tzinfo-data', platforms: %i[
-  mingw mswin x64_mingw jruby
-]
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+
+# Faster JSON marshalling
+gem 'oj'
+
+# https://jsonapi.org/ spec implementation
+gem 'jsonapi.rb'
 
 ## MAYBE INSTALL
 # gem "redis", "~> 4.0"
@@ -43,5 +47,6 @@ group :test do
   gem 'database_cleaner', '~> 1.7.0'
   gem 'rspec-json_expectations'
   gem 'rspec-rails', '~> 6.0.0.rc1'
+  gem 'jsonapi-rspec'
   gem 'timecop', '0.9.5'
 end

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -126,6 +126,14 @@ GEM
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
     json (2.6.3)
+    jsonapi-rspec (0.0.11)
+      rspec-core
+      rspec-expectations
+    jsonapi-serializer (2.2.0)
+      activesupport (>= 4.2)
+    jsonapi.rb (2.0.1)
+      jsonapi-serializer
+      rack
     launchy (2.5.2)
       addressable (~> 2.8)
     letter_opener (1.8.1)
@@ -171,6 +179,7 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    oj (3.14.2)
     orm_adapter (0.5.0)
     parallel (1.22.1)
     parser (3.2.1.0)
@@ -304,8 +313,11 @@ DEPENDENCIES
   guard
   guard-rspec
   image_processing (~> 1.2)
+  jsonapi-rspec
+  jsonapi.rb
   letter_opener
   letter_opener_web
+  oj
   pg (~> 1.1)
   puma (~> 5.0)
   rack-cors

--- a/backend/app/controllers/api/application_controller.rb
+++ b/backend/app/controllers/api/application_controller.rb
@@ -3,7 +3,25 @@
 module Api
   class ApplicationController < ActionController::API
     include DeviseTokenAuth::Concerns::SetUserByToken
+    include Api::ExceptionHandler
+    include Api::JsonApi
 
-    respond_to :json
+    before_action :logged_and_confirmed!
+
+    private
+
+    def logged_and_confirmed!
+      raise Exceptions::Unauthorized unless user_signed_in?
+    end
+
+    def user_signed_in?
+      api_user_signed_in? && current_user.confirmed?
+    end
+
+    # Syntax sugar because generated method is based
+    # on route namespace. I don't like but it's what it is
+    def current_user
+      current_api_user
+    end
   end
 end

--- a/backend/app/controllers/api/people_controller.rb
+++ b/backend/app/controllers/api/people_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Api
+  class PeopleController < ApplicationController
+    def index
+      jsonapi_paginate(collection) do |paginated|
+        render jsonapi: paginated
+      end
+    end
+
+    private
+
+    def collection
+      # TODO: Move to a `RecommendedPeopleCollection`
+      # This will filter by:
+      # 1. GEO location
+      # 2. Gender preferences (study!)
+      Person.without_user(current_user)
+    end
+  end
+end

--- a/backend/app/controllers/concerns/api/exception_handler.rb
+++ b/backend/app/controllers/concerns/api/exception_handler.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Api
+  module ExceptionHandler
+    extend ActiveSupport::Concern
+
+    # Some exceptions are already defined in
+    # JSONAPI::Errors
+    included do
+      rescue_from Exceptions::Unauthorized do
+        error = { status: '401', title: Rack::Utils::HTTP_STATUS_CODES[401] }
+        render jsonapi_errors: [error], status: :unauthorized
+      end
+    end
+  end
+end

--- a/backend/app/controllers/concerns/api/json_api.rb
+++ b/backend/app/controllers/concerns/api/json_api.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Api
+  # JSONAPI customizations
+  # https://github.com/stas/jsonapi.rb
+  #
+  # The idea is to have all related JSON API gem
+  # here.
+  module JsonApi
+    extend ActiveSupport::Concern
+
+    included do
+      # JSONAPI includes
+      include JSONAPI::Errors
+      include JSONAPI::Pagination
+
+      private
+
+      def render_jsonapi_internal_server_error(exception)
+        # TODO: Use Sentry and call it here
+        Rails.logger.error(exception)
+        super(exception)
+      end
+
+      def jsonapi_meta(resources)
+        meta = {}
+        pagination = jsonapi_pagination_meta(resources)
+
+        meta = meta.merge(total: resources.count) if resources.respond_to?(:count)
+
+        meta = meta.merge(pagination:) if pagination.present?
+
+        meta
+      end
+
+      # By default try to use naming conventions
+      def jsonapi_serializer_class(resource, is_collection)
+        JSONAPI::Rails.serializer_class(resource, is_collection)
+      rescue NameError
+        klass = resource.class
+        klass = resource.first.class if is_collection
+        "Custom#{klass.name}Serializer".constantize
+      end
+    end
+  end
+end

--- a/backend/app/models/person.rb
+++ b/backend/app/models/person.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Person < ApplicationRecord
+  belongs_to :user
+
+  # Scopes
+  scope :without_user, lambda { |user|
+    where.not(user:)
+  }
+end

--- a/backend/app/serializers/base_serializer.rb
+++ b/backend/app/serializers/base_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'oj'
+
+class BaseSerializer
+  include JSONAPI::Serializer
+
+  def to_json(*_args)
+    Oj.dump(serializable_hash, mode: :compat)
+  end
+
+  alias serialized_json to_json
+end

--- a/backend/app/serializers/person_serializer.rb
+++ b/backend/app/serializers/person_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class PersonSerializer < BaseSerializer
+  attributes :name, :birthday
+end

--- a/backend/app/services/exceptions.rb
+++ b/backend/app/services/exceptions.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Exceptions
+  Unauthorized = Class.new(StandardError)
+end

--- a/backend/config/initializers/jsonapi.rb
+++ b/backend/config/initializers/jsonapi.rb
@@ -1,0 +1,3 @@
+require 'jsonapi'
+
+JSONAPI::Rails.install!

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  get 'people/index'
   # Mobile and web apps use this API
   namespace :api do
     mount_devise_token_auth_for(
@@ -11,6 +12,9 @@ Rails.application.routes.draw do
         registrations: 'api/auth_overrides/registrations'
       }
     )
+
+    # All the love goes here
+    resources :people, only: %i[index]
   end
 
   if Rails.env.development?

--- a/backend/db/migrate/20230312105319_create_people.rb
+++ b/backend/db/migrate/20230312105319_create_people.rb
@@ -1,0 +1,11 @@
+class CreatePeople < ActiveRecord::Migration[7.0]
+  def change
+    create_table :people do |t|
+      t.string :name, null: false
+      t.date :birthday
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_26_093859) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_12_105319) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "people", force: :cascade do |t|
+    t.string "name", null: false
+    t.date "birthday"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_people_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "uid", default: "", null: false
@@ -41,4 +50,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_26_093859) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "people", "users"
 end

--- a/backend/spec/factories/people.rb
+++ b/backend/spec/factories/people.rb
@@ -1,0 +1,26 @@
+# typed: false
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :person do
+    birthday { Date.new(1998, 3, 3) }
+    user
+
+    trait :woman do
+      name { Faker::Name.female_first_name }
+    end
+
+    trait :man do
+      name { Faker::Name.male_first_name }
+    end
+
+    trait :confirmed do
+      transient do
+        is_confirmed { true }
+      end
+      after(:create) do |person, evaluator|
+        person.user.confirm if evaluator.is_confirmed
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/people/list_spec.rb
+++ b/backend/spec/requests/api/people/list_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe '#list' do
+  let(:is_confirmed) { false }
+  let(:frank) do
+    create(
+      :person,
+      :man,
+      :confirmed,
+      is_confirmed:
+    )
+  end
+  let(:user) { frank.user }
+
+  let(:action) { get '/api/people', headers: jsonapi_headers }
+
+  it_behaves_like 'unauthorized', :user
+
+  context 'when logged and confirmed' do
+    let(:is_confirmed) { true }
+    # List of people
+    let(:clara_confirmed) { true }
+    let!(:clara) do
+      create(
+        :person,
+        :woman,
+        :confirmed,
+        is_confirmed: clara_confirmed
+      )
+    end
+
+    let(:user) { frank.user }
+
+    api_sign_in(:user)
+
+    before { action }
+
+    it 'returns a siccess status' do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'sets json api type' do
+      expect(json_body['data'].first).to have_type('person')
+    end
+
+    it 'gets meta' do
+      expect(json_body).to have_meta(
+        total: 1,
+        pagination: { current: 1, records: 1 }
+      )
+    end
+
+    it 'excludes ifself from the list' do
+      expect(json_body['data'].size).to be(1)
+    end
+
+    it 'returns a list of people' do
+      clara_response = json_body['data'].first
+      expect(clara_response).to have_attribute(:name).with_value(clara.name)
+      expect(clara_response).to have_attribute(:birthday).with_value(clara.birthday.as_json)
+    end
+  end
+end

--- a/backend/spec/support/jsonapi.rb
+++ b/backend/spec/support/jsonapi.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'jsonapi/rspec'
+require_relative './requests/json_api'
+
+RSpec.configure do |config|
+  config.include JSONAPI::RSpec
+  config.include Requests::JsonApi::Helpers
+
+  # Support for documents with mixed string/symbol keys.
+  # Disabled by default.
+  config.jsonapi_indifferent_hash = true
+end

--- a/backend/spec/support/requests/json_api.rb
+++ b/backend/spec/support/requests/json_api.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Requests
+  module JsonApi
+    module Helpers
+      # Helper to return JSONAPI valid headers
+      #
+      # @return [Hash] the relevant content type &co
+      def jsonapi_headers
+        { 'Content-Type' => Mime[:jsonapi].to_s }
+      end
+
+      def json_body
+        JSON.parse(response.body)
+      end
+    end
+  end
+end

--- a/backend/spec/support/shared_examples/unauthorized.rb
+++ b/backend/spec/support/shared_examples/unauthorized.rb
@@ -1,24 +1,22 @@
 # typed: false
 # frozen_string_literal: true
 
-RSpec.shared_examples 'unauthorized' do
+RSpec.shared_examples 'unauthorized' do |user|
   context 'when not authenticated' do
     it 'returns 401' do
       action
 
       expect(response).to have_http_status(:unauthorized)
     end
-  end
-end
 
-RSpec.shared_examples 'staff_only' do
-  context 'when not authorized' do
-    before { sign_in user }
+    context 'when logged but not confirmed' do
+      api_sign_in(user)
 
-    it 'returns 403' do
-      action
+      it 'returns 401' do
+        action
 
-      expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
   end
 end


### PR DESCRIPTION
# WAT?
Implement `/api/people` following [jsonapi.org specification](https://jsonapi.org) 

I want to learn how to do an API that follows https://jsonapi.org/ specification because I want to give it a try. Also under the hood the gem that use this spec is faster than default Rails API serializer so that's another reason.

In following iterations I'll do the logic to geolocate people based on logged person requesting info to `/api/people`. For now is a dummy list of people in the db without any criteria.

## TODO
- [x] Serialize [JSON response with this gem](https://github.com/jsonapi-serializer/jsonapi-serializer)  by using [jsonapi.rb](https://github.com/stas/jsonapi.rb)
- [x] Use [OJ](https://github.com/ohler55/oj) for faster JSON marshaling 
- [x] Check user is logged in and is also confirmed when accessing `/api/people`
- [x] Do `PersonSerializer` 