### PR TITLE
Introduce Geo powers to person model

### DIFF
--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -11,6 +11,9 @@ Style/Documentation:
 Metrics/BlockLength:
   Enabled: false
 
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: 'consistent'
+
 # RSpec
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
@@ -18,6 +21,10 @@ RSpec/ExampleLength:
   Enabled: false
 RSpec/MultipleExpectations:
   Enabled: false
+RSpec/LetSetup:
+  Enabled: false
+RSpec/NestedGroups:
+  Max: 6
 
 AllCops:
   NewCops: enable

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -21,6 +21,7 @@ gem 'oj'
 
 # https://jsonapi.org/ spec implementation
 gem 'jsonapi.rb'
+gem 'activerecord-postgis-adapter'
 
 ## MAYBE INSTALL
 # gem "redis", "~> 4.0"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -54,6 +54,9 @@ GEM
     activerecord (7.0.4.2)
       activemodel (= 7.0.4.2)
       activesupport (= 7.0.4.2)
+    activerecord-postgis-adapter (8.0.1)
+      activerecord (~> 7.0.0)
+      rgeo-activerecord (~> 7.0.0)
     activestorage (7.0.4.2)
       actionpack (= 7.0.4.2)
       activejob (= 7.0.4.2)
@@ -233,6 +236,10 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.5)
+    rgeo (3.0.0)
+    rgeo-activerecord (7.0.1)
+      activerecord (>= 5.0)
+      rgeo (>= 1.0.0)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -302,6 +309,7 @@ PLATFORMS
   arm64-darwin-21
 
 DEPENDENCIES
+  activerecord-postgis-adapter
   bootsnap
   byebug
   database_cleaner (~> 1.7.0)

--- a/backend/app/controllers/api/people_controller.rb
+++ b/backend/app/controllers/api/people_controller.rb
@@ -11,11 +11,7 @@ module Api
     private
 
     def collection
-      # TODO: Move to a `RecommendedPeopleCollection`
-      # This will filter by:
-      # 1. GEO location
-      # 2. Gender preferences (study!)
-      Person.without_user(current_user)
+      @collection ||= PeopleRepository.new(current_user).scope
     end
   end
 end

--- a/backend/app/models/person.rb
+++ b/backend/app/models/person.rb
@@ -1,10 +1,62 @@
 # frozen_string_literal: true
 
 class Person < ApplicationRecord
+  # https://epsg.io/4326
+  WGS84_SRID = 4326
+  DEFAULT_DISTANCE_IN_KM = 10_000
+
+  # Relations
   belongs_to :user
 
   # Scopes
   scope :without_user, lambda { |user|
     where.not(user:)
   }
+  scope :confirmed, lambda {
+    includes(:user)
+      .where
+      .not(user: { confirmed_at: nil })
+  }
+  scope :within_person_range, lambda { |person|
+    where(person.radius_query)
+  }
+
+  def radius_query
+    # https://postgis.net/docs/ST_Point.html
+    # For geodetic coordinates, X is longitude and Y is latitude
+    "ST_DWithin(
+      lonlat::geography,
+      'SRID=#{WGS84_SRID};POINT(#{longitude} #{latitude})'::geography,
+      #{radius_in_meters})
+    ".squish
+  end
+
+  # Add a virtual column to people query with the distance in
+  # meters from a point to the list of people in the query
+  #
+  # @return RGeo::ActiveRecord::SpatialNamedFunction
+  def distance_in_meters_field
+    table = Arel::Table.new('people')
+    table[:lonlat].st_distance(
+      lonlat
+    ).as('distance_in_meters')
+  end
+
+  private
+
+  def longitude
+    lonlat&.lon
+  end
+
+  def latitude
+    lonlat&.lat
+  end
+
+  def radius_in_meters
+    radius_in_km * 1000
+  end
+
+  def radius_in_km
+    search_range_in_km || DEFAULT_DISTANCE_IN_KM
+  end
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -13,4 +13,7 @@ class User < ApplicationRecord
     :confirmable,
     :trackable
   )
+
+  # Relations
+  has_one :person, dependent: :destroy
 end

--- a/backend/app/repositories/base_repository.rb
+++ b/backend/app/repositories/base_repository.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class BaseRepository
+  def initialize(user)
+    @current_user = user
+  end
+
+  # Abstract method
+  def scope; end
+
+  protected
+
+  attr_reader :current_user
+end

--- a/backend/app/repositories/people_repository.rb
+++ b/backend/app/repositories/people_repository.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class PeopleRepository < BaseRepository
+  def scope
+    return Person.none if current_user.person&.lonlat.nil?
+
+    people.select(
+      Arel.star,
+      person.distance_in_meters_field
+    ).order(distance_in_meters: :asc)
+  end
+
+  private
+
+  def people
+    Person
+      .without_user(current_user)
+      .confirmed
+      .within_person_range(person)
+  end
+
+  def person
+    @person ||= current_user.person
+  end
+end

--- a/backend/app/serializers/person_serializer.rb
+++ b/backend/app/serializers/person_serializer.rb
@@ -2,4 +2,9 @@
 
 class PersonSerializer < BaseSerializer
   attributes :name, :birthday
+
+  # Ex.: 6.6 km
+  attribute :distance_in_km do |object|
+    (object.distance_in_meters / 1000).round(1)
+  end
 end

--- a/backend/config/database.yml
+++ b/backend/config/database.yml
@@ -1,5 +1,5 @@
 default: &default
-  adapter: postgresql
+  adapter: postgis
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   port: 5432

--- a/backend/db/migrate/20230312105319_create_people.rb
+++ b/backend/db/migrate/20230312105319_create_people.rb
@@ -3,7 +3,12 @@ class CreatePeople < ActiveRecord::Migration[7.0]
     create_table :people do |t|
       t.string :name, null: false
       t.date :birthday
-      t.references :user, null: false, foreign_key: true
+      t.references(
+        :user,
+        null: false,
+        foreign_key: { on_delete: :cascade },
+        index: { unique: true }
+      )
 
       t.timestamps
     end

--- a/backend/db/migrate/20230316122717_add_postgis_extension_to_database.rb
+++ b/backend/db/migrate/20230316122717_add_postgis_extension_to_database.rb
@@ -1,0 +1,5 @@
+class AddPostgisExtensionToDatabase < ActiveRecord::Migration[7.0]
+  def change
+    enable_extension 'postgis'
+  end
+end

--- a/backend/db/migrate/20230316130038_add_lat_long_to_person.rb
+++ b/backend/db/migrate/20230316130038_add_lat_long_to_person.rb
@@ -1,0 +1,7 @@
+class AddLatLongToPerson < ActiveRecord::Migration[7.0]
+  def change
+    add_column :people, :lonlat, :st_point, geographic: true
+    add_column :people, :search_range_in_km, :integer, null: true
+    add_index :people, :lonlat, using: :gist
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_12_105319) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_16_130038) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "postgis"
 
   create_table "people", force: :cascade do |t|
     t.string "name", null: false
@@ -20,7 +21,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_12_105319) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_people_on_user_id"
+    t.geography "lonlat", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
+    t.integer "search_range_in_km"
+    t.index ["lonlat"], name: "index_people_on_lonlat", using: :gist
+    t.index ["user_id"], name: "index_people_on_user_id", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -50,5 +54,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_12_105319) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
-  add_foreign_key "people", "users"
+  add_foreign_key "people", "users", on_delete: :cascade
 end

--- a/backend/spec/requests/api/people/list_spec.rb
+++ b/backend/spec/requests/api/people/list_spec.rb
@@ -4,12 +4,19 @@ require 'rails_helper'
 
 describe '#list' do
   let(:is_confirmed) { false }
+  let(:search_range_in_km) { nil }
+  let(:frank_lonlat) do
+    # Plaza Catalunya
+    'POINT(2.170041 41.387022)'
+  end
   let(:frank) do
     create(
       :person,
       :man,
       :confirmed,
-      is_confirmed:
+      is_confirmed:,
+      lonlat: frank_lonlat,
+      search_range_in_km:
     )
   end
   let(:user) { frank.user }
@@ -22,12 +29,20 @@ describe '#list' do
     let(:is_confirmed) { true }
     # List of people
     let(:clara_confirmed) { true }
+    let(:lonlat) do
+      # Valencia
+      'POINT(-0.376335 39.469707)'
+    end
+    let!(:maria) { nil }
+    let!(:jessica) { nil }
     let!(:clara) do
       create(
         :person,
         :woman,
         :confirmed,
-        is_confirmed: clara_confirmed
+        is_confirmed: clara_confirmed,
+        lonlat:,
+        name: 'Clara'
       )
     end
 
@@ -37,7 +52,7 @@ describe '#list' do
 
     before { action }
 
-    it 'returns a siccess status' do
+    it 'returns a success status' do
       expect(response).to have_http_status(:success)
     end
 
@@ -56,10 +71,92 @@ describe '#list' do
       expect(json_body['data'].size).to be(1)
     end
 
-    it 'returns a list of people' do
+    # Important to don't look empty when this
+    # get started. They always wil be able to change distance range filter of course.
+    it 'returns a list of people within default distance range (10.000 km)' do
       clara_response = json_body['data'].first
       expect(clara_response).to have_attribute(:name).with_value(clara.name)
       expect(clara_response).to have_attribute(:birthday).with_value(clara.birthday.as_json)
+    end
+
+    context "when frank's location is not set" do
+      let(:frank_lonlat) { nil }
+
+      it_behaves_like 'empty_collection'
+    end
+
+    context "when Clara's location is not set" do
+      let(:lonlat) { nil }
+
+      it_behaves_like 'empty_collection'
+    end
+
+    context 'when clara is not confirmed' do
+      let(:clara_confirmed) { false }
+
+      it_behaves_like 'empty_collection'
+    end
+
+    context 'when frank sets a smaller search range' do
+      let(:search_range_in_km) { 50 }
+
+      it_behaves_like 'empty_collection'
+
+      context 'when clara moves near frank' do
+        let(:lonlat) do
+          # L'Hospitalet de Llobregat
+          'POINT(2.099574 41.359592)'
+        end
+
+        it 'clara is a possible match' do
+          expect(json_body['data'].size).to eq(1)
+        end
+
+        it 'calculates distance between current user and people' do
+          expect(json_body['data'].first)
+            .to have_attribute(:distance_in_km)
+            .with_value(6.6)
+        end
+
+        context 'when more than one person in the list' do
+          let!(:maria) do
+            create(
+              :person,
+              :woman,
+              :confirmed,
+              # Plaza Universitat
+              lonlat: 'POINT(2.1649662 41.3864746)',
+              name: 'Maria'
+            )
+          end
+          let!(:jessica) do
+            create(
+              :person,
+              :woman,
+              :confirmed,
+              # Badalona
+              lonlat: 'POINT(2.2482836 41.4433835)',
+              name: 'Jessica'
+            )
+          end
+          let(:people) do
+            json_body['data'].map do |person|
+              {
+                name: person.dig('attributes', 'name'),
+                distance_in_km: person.dig('attributes', 'distance_in_km')
+              }
+            end
+          end
+
+          it 'sort by distance' do
+            expect(people).to eq([
+              { name: 'Maria', distance_in_km: 0.4 },
+              { name: 'Clara', distance_in_km: 6.6 },
+              { name: 'Jessica', distance_in_km: 9.1 }
+            ])
+          end
+        end
+      end
     end
   end
 end

--- a/backend/spec/support/shared_examples/collections.rb
+++ b/backend/spec/support/shared_examples/collections.rb
@@ -1,0 +1,8 @@
+# typed: false
+# frozen_string_literal: true
+
+RSpec.shared_examples 'empty_collection' do |_user|
+  it 'returns 0 items' do
+    expect(json_body['data']).to be_empty
+  end
+end


### PR DESCRIPTION
# WAT?
This is the first step to be able to list by person lat/long the people that are near them.

## TODO
- [x] Setup Rails ActiveRecord integration with Postgis (Geo functions plugin for PostgreSQL)
- [x] Add field `lonlat` geo column for longitude / latitude to geo position people
- [x] Filter `/api/people` by `lonlat` geo position near current user + specs
- [x] Calculate distance from current user to each person in the list of possible matches
- [x] Order result by distance from current user to all possible people in the list (closest first)