### PR TITLE
Add gender, gender preference and sexuality to person

### DIFF
--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -25,6 +25,8 @@ RSpec/LetSetup:
   Enabled: false
 RSpec/NestedGroups:
   Max: 6
+RSpec/ImplicitSubject:
+  Enabled: false
 
 AllCops:
   NewCops: enable

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -22,6 +22,7 @@ gem 'oj'
 # https://jsonapi.org/ spec implementation
 gem 'jsonapi.rb'
 gem 'activerecord-postgis-adapter'
+gem 'assignable_values'
 
 ## MAYBE INSTALL
 # gem "redis", "~> 4.0"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -71,6 +71,8 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
+    assignable_values (0.18.0)
+      activerecord (>= 2.3)
     ast (2.4.2)
     bcrypt (3.1.18)
     bootsnap (1.16.0)
@@ -310,6 +312,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-postgis-adapter
+  assignable_values
   bootsnap
   byebug
   database_cleaner (~> 1.7.0)

--- a/backend/app/models/concerns/people/with_gender.rb
+++ b/backend/app/models/concerns/people/with_gender.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module People
+  module WithGender
+    extend ActiveSupport::Concern
+    GENDER = %w[
+      woman
+      man
+      nonbinary
+      transgender_woman
+      transgender_man
+    ].freeze
+    GENDER_EVERYONE = 'everyone'
+    GENDER_PREFERENCE = GENDER + [GENDER_EVERYONE]
+
+    class_methods do
+      def everyone
+        GENDER_EVERYONE
+      end
+
+      def all_genders
+        @all_genders ||= GENDER
+      end
+
+      def all_genders_sql
+        @all_genders_sql ||= all_genders.map do |gen|
+          "\"#{gen}\""
+        end.join(',')
+      end
+
+      def people_gender_preference_query
+        <<-SQL
+          CASE WHEN 'everyone' = ANY(gender_preference)
+          THEN gender_preference && :all_genders
+          ELSE
+          :person_gender = ANY(gender_preference)
+          END
+        SQL
+          .squish
+      end
+    end
+
+    included do
+      assignable_values_for(
+        :gender,
+        allow_blank: true
+      ) do
+        GENDER
+      end
+      assignable_values_for(
+        :gender_preference,
+        multiple: true,
+        allow_blank: true
+      ) do
+        GENDER_PREFERENCE
+      end
+      scope :with_gender, lambda { |person|
+        where(gender: person.gender_preferences).where(
+          Person.people_gender_preference_query,
+          person_gender: person.gender,
+          all_genders: "{#{Person.all_genders_sql}}"
+        )
+      }
+
+      def gender_preferences
+        return Person.all_genders if gender_preference.include?(Person.everyone)
+
+        gender_preference
+      end
+    end
+  end
+end

--- a/backend/app/models/concerns/people/with_location.rb
+++ b/backend/app/models/concerns/people/with_location.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module People
+  module WithLocation
+    extend ActiveSupport::Concern
+
+    # https://epsg.io/4326
+    WGS84_SRID = 4326
+    DEFAULT_DISTANCE_IN_KM = 10_000
+
+    included do
+      scope :with_location, lambda { |person|
+        where(person.radius_query)
+      }
+
+      def radius_query
+        # https://postgis.net/docs/ST_Point.html
+        # For geodetic coordinates, X is longitude and Y is latitude
+        "ST_DWithin(
+          lonlat::geography,
+          'SRID=#{WGS84_SRID};POINT(#{longitude} #{latitude})'::geography,
+          #{radius_in_meters})
+          ".squish
+      end
+
+      # Add a virtual column to people query with the distance in
+      # meters from a point to the list of people in the query
+      #
+      # @return RGeo::ActiveRecord::SpatialNamedFunction
+      def distance_in_meters_field
+        table = Arel::Table.new('people')
+        table[:lonlat].st_distance(
+          lonlat
+        ).as('distance_in_meters')
+      end
+
+      private
+
+      def longitude
+        lonlat&.lon
+      end
+
+      def latitude
+        lonlat&.lat
+      end
+
+      def radius_in_meters
+        radius_in_km * 1000
+      end
+
+      def radius_in_km
+        search_range_in_km || DEFAULT_DISTANCE_IN_KM
+      end
+    end
+  end
+end

--- a/backend/app/models/concerns/people/with_sexuality.rb
+++ b/backend/app/models/concerns/people/with_sexuality.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module People
+  module WithSexuality
+    extend ActiveSupport::Concern
+
+    SEXUALITY = %w[
+      prefer_not_to_say
+      straight
+      gay
+      lesbian
+      bisexual
+      allosexual
+      androsexual
+      asexual
+      autosexual
+      bicurious
+      demisexual
+      fluid
+      graysexual
+      polysexual
+      pansexual
+      queer
+      questioning
+      skoliosexual
+      not_listed
+    ].freeze
+
+    included do
+      assignable_values_for(
+        :sexuality,
+        allow_blank: true
+      ) do
+        SEXUALITY
+      end
+    end
+  end
+end

--- a/backend/app/models/concerns/people/with_user.rb
+++ b/backend/app/models/concerns/people/with_user.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module People
+  module WithUser
+    extend ActiveSupport::Concern
+
+    included do
+      belongs_to :user
+
+      scope :without_user, lambda { |user|
+        where.not(user:)
+      }
+      scope :with_confirmed_users, lambda {
+        includes(:user)
+          .where
+          .not(user: { confirmed_at: nil })
+      }
+    end
+  end
+end

--- a/backend/app/repositories/people_repository.rb
+++ b/backend/app/repositories/people_repository.rb
@@ -2,7 +2,7 @@
 
 class PeopleRepository < BaseRepository
   def scope
-    return Person.none if current_user.person&.lonlat.nil?
+    return Person.none unless person.ready_to_love?
 
     people.select(
       Arel.star,
@@ -15,8 +15,9 @@ class PeopleRepository < BaseRepository
   def people
     Person
       .without_user(current_user)
-      .confirmed
-      .within_person_range(person)
+      .with_confirmed_users
+      .with_location(person)
+      .with_gender(person)
   end
 
   def person

--- a/backend/app/serializers/person_serializer.rb
+++ b/backend/app/serializers/person_serializer.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 class PersonSerializer < BaseSerializer
-  attributes :name, :birthday
+  attributes(
+    :name,
+    :birthday,
+    :gender_visible,
+    :sexuality_visible
+  )
+
+  attribute :gender, &:humanized_gender
+  attribute :sexuality, &:humanized_sexuality
 
   # Ex.: 6.6 km
   attribute :distance_in_km do |object|

--- a/backend/config/locales/en.yml
+++ b/backend/config/locales/en.yml
@@ -1,2 +1,35 @@
 en:
-  hello: "Hello world"
+  all_genders: &default
+    woman: 'Woman'
+    man: 'Man'
+    nonbinary: 'Non-binary'
+    transgender_woman: 'Transgender/Trans woman'
+    transgender_man: 'Transgender/Trans man'
+  assignable_values:
+    person:
+      gender:
+        <<: *default
+      gender_preference:
+        <<: *default
+        everyone: 'Everyone'
+      sexuality:
+        prefer_not_to_say: 'Prefer not to say'
+        straight: 'Straight'
+        gay: 'Gay'
+        lesbian: 'Lesbian'
+        bisexual: 'Bisexual'
+        allosexual: 'Allosexual'
+        androsexual: 'Androsexual'
+        asexual: 'Asexual'
+        autosexual: 'Autosexual'
+        bicurious: 'Bicurious'
+        demisexual: 'Demisexual'
+        fluid: 'Fluid'
+        graysexual: 'Graysexual'
+        polysexual: 'Polysexual'
+        pansexual: 'Pansexual'
+        queer: 'Queer'
+        questioning: 'Questioning'
+        skoliosexual: 'Skoliosexual'
+        not_listed: 'Not listed'
+

--- a/backend/db/migrate/20230318135347_add_gender_and_gender_preference_to_person.rb
+++ b/backend/db/migrate/20230318135347_add_gender_and_gender_preference_to_person.rb
@@ -1,0 +1,16 @@
+class AddGenderAndGenderPreferenceToPerson < ActiveRecord::Migration[7.0]
+  def change
+    add_column :people, :gender, :string, null: true
+    add_column :people, :sexuality, :string, null: true
+    add_column :people, :sexuality_visible, :boolean, null: false, default: true
+    add_column :people, :gender_visible, :boolean, null: false, default: true
+    add_column(
+      :people,
+      :gender_preference,
+      :string,
+      array: true,
+      null: false,
+      default: []
+    )
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_16_130038) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_18_135347) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -23,6 +23,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_16_130038) do
     t.datetime "updated_at", null: false
     t.geography "lonlat", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
     t.integer "search_range_in_km"
+    t.string "gender"
+    t.string "sexuality"
+    t.boolean "sexuality_visible", default: true, null: false
+    t.boolean "gender_visible", default: true, null: false
+    t.string "gender_preference", default: [], null: false, array: true
     t.index ["lonlat"], name: "index_people_on_lonlat", using: :gist
     t.index ["user_id"], name: "index_people_on_user_id", unique: true
   end

--- a/backend/spec/factories/people.rb
+++ b/backend/spec/factories/people.rb
@@ -4,14 +4,20 @@
 FactoryBot.define do
   factory :person do
     birthday { Date.new(1998, 3, 3) }
+    name { Faker::Name.female_first_name }
+    sexuality { 'prefer_not_to_say' }
     user
 
-    trait :woman do
+    trait :straight_woman do
       name { Faker::Name.female_first_name }
+      gender { 'woman' }
+      gender_preference { %w[man] }
     end
 
-    trait :man do
+    trait :straight_man do
       name { Faker::Name.male_first_name }
+      gender { 'man' }
+      gender_preference { %w[woman] }
     end
 
     trait :confirmed do

--- a/backend/spec/model/person_spec.rb
+++ b/backend/spec/model/person_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Person, type: :model do
+  let(:gender) { 'woman' }
+  let(:sexuality) { 'pansexual' }
+  let(:gender_preference) { %w[woman man nonbinary] }
+  let(:model) do
+    build(
+      :person,
+      gender:,
+      gender_preference:,
+      sexuality:
+    )
+  end
+
+  describe 'validations' do
+    subject { model }
+
+    describe '#gender' do
+      it { is_expected.to be_valid }
+
+      context 'when not-recognized' do
+        it 'does not allow not valid gender' do
+          model.gender = 'foobar'
+          is_expected.to be_invalid
+        end
+      end
+    end
+
+    describe '#gender_preference' do
+      it { is_expected.to be_valid }
+
+      context 'when not-recognized' do
+        it 'does not allow not valid gender' do
+          model.gender_preference = %w[foobar]
+          is_expected.to be_invalid
+        end
+      end
+    end
+
+    describe '#sexuality' do
+      it { is_expected.to be_valid }
+
+      context 'when not-recognized' do
+        it 'does not allow not valid term' do
+          model.sexuality = 'non-existing-term'
+          is_expected.to be_invalid
+        end
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/people/list_by_gender_spec.rb
+++ b/backend/spec/requests/api/people/list_by_gender_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe '#list_by_gender' do
+  let(:search_range_in_km) { nil }
+  let(:frank_gender) { 'man' }
+  let(:frank_gender_preference) { ['woman'] }
+  let(:frank) do
+    create(
+      :person,
+      :confirmed,
+      # Plaza Catalunya
+      lonlat: 'POINT(2.170041 41.387022)',
+      gender: frank_gender,
+      gender_preference: frank_gender_preference,
+      search_range_in_km: 50
+    )
+  end
+  let(:user) { frank.user }
+  let(:action) { get '/api/people', headers: jsonapi_headers }
+
+  let(:clara_gender) { :woman }
+  let(:clara_gender_preference) { ['man'] }
+
+  let!(:clara) do
+    create(
+      :person,
+      :confirmed,
+      # Badalona
+      lonlat: 'POINT(2.2482836 41.4433835)',
+      gender: clara_gender,
+      gender_preference: clara_gender_preference
+    )
+  end
+
+  api_sign_in(:user)
+  before { action }
+
+  it_behaves_like 'collection_with_one'
+
+  it 'display gender attributes' do
+    clara_response = json_body['data'].first
+
+    expect(clara_response)
+      .to have_attribute(:gender).with_value('Woman')
+    expect(clara_response)
+      .to have_attribute(:sexuality).with_value('Prefer not to say')
+    expect(clara_response)
+      .to have_attribute(:gender_visible)
+      .with_value(true)
+    expect(clara_response)
+      .to have_attribute(:sexuality_visible)
+      .with_value(true)
+  end
+
+  context "when frank's gender preference is not set" do
+    let(:frank_gender_preference) { [] }
+
+    it_behaves_like 'empty_collection'
+  end
+
+  context "when frank's gender is not set" do
+    let(:frank_gender) { nil }
+
+    it_behaves_like 'empty_collection'
+  end
+
+  context "when clara's gender is not set" do
+    let(:clara_gender) { nil }
+
+    it_behaves_like 'empty_collection'
+  end
+
+  context "when clara's gender preference is not set" do
+    let(:clara_gender_preference) { [] }
+
+    it_behaves_like 'empty_collection'
+  end
+
+  context 'when a Clara wants to date another women' do
+    let(:clara_gender_preference) { [:woman] }
+
+    it_behaves_like 'empty_collection'
+  end
+
+  context "when clara's is a transgender woman" do
+    let(:clara_gender) { :transgender_woman }
+
+    it_behaves_like 'empty_collection'
+
+    context 'when Clara choose everyone' do
+      let(:clara_gender_preference) { [Person.everyone] }
+
+      it_behaves_like 'empty_collection'
+    end
+
+    context 'when frank choose woman and transgender woman' do
+      let(:frank_gender_preference) { %w[woman transgender_woman] }
+
+      it_behaves_like 'collection_with_one'
+    end
+
+    context 'when frank choose everyone' do
+      let(:frank_gender_preference) { [Person.everyone] }
+
+      it_behaves_like 'collection_with_one'
+    end
+  end
+end

--- a/backend/spec/requests/api/people/list_spec.rb
+++ b/backend/spec/requests/api/people/list_spec.rb
@@ -12,7 +12,7 @@ describe '#list' do
   let(:frank) do
     create(
       :person,
-      :man,
+      :straight_man,
       :confirmed,
       is_confirmed:,
       lonlat: frank_lonlat,
@@ -38,7 +38,7 @@ describe '#list' do
     let!(:clara) do
       create(
         :person,
-        :woman,
+        :straight_woman,
         :confirmed,
         is_confirmed: clara_confirmed,
         lonlat:,
@@ -122,7 +122,7 @@ describe '#list' do
           let!(:maria) do
             create(
               :person,
-              :woman,
+              :straight_woman,
               :confirmed,
               # Plaza Universitat
               lonlat: 'POINT(2.1649662 41.3864746)',
@@ -132,7 +132,7 @@ describe '#list' do
           let!(:jessica) do
             create(
               :person,
-              :woman,
+              :straight_woman,
               :confirmed,
               # Badalona
               lonlat: 'POINT(2.2482836 41.4433835)',

--- a/backend/spec/support/shared_examples/collections.rb
+++ b/backend/spec/support/shared_examples/collections.rb
@@ -1,8 +1,14 @@
 # typed: false
 # frozen_string_literal: true
 
-RSpec.shared_examples 'empty_collection' do |_user|
+RSpec.shared_examples 'empty_collection' do
   it 'returns 0 items' do
     expect(json_body['data']).to be_empty
+  end
+end
+
+RSpec.shared_examples 'collection_with_one' do
+  it 'returns one item' do
+    expect(json_body['data'].size).to be(1)
   end
 end


### PR DESCRIPTION
# WAT?
With this change is possible to filter by gender preference the people that users want to match and date.

## TODO
- [x] Filter by `gender` people 
- [x] Do not show people that does not have setup `gender` and `gender_preference`.
- [x] Only show people that match current user's `gender_preference`
- [x] Do not show a person that want to date one gender to other genders. Ex.: A woman that want to date only women does not have to appear to a man that want to date women. This is obvious but has to be programed : )
- [x] Move all geo methods in `Person` to `People::WithLocation` model concern
- [x] Validate `gender` is valid with a model spec
- [x] Validate `gender_preference` is valid with a model spec.
- [x] Validate `sexuality` is valid with a model spec.
- [x] Add option to hide `gender` from person's profile
- [x] Display `gender` in person serializer translated if `gender_visible` flag is `true`. (by default true)
- [x] Add `sexuality` and `sexuality_visible` columns and add it to serializer if visible (by default true)

### References
[Inclusive language guidelines](https://www.csusm.edu/ipa/surveys/inclusive-language-guidelines.html)
[How to question about gender and sexuality?](https://irb.utah.edu/_resources/documents/pdf/IGS%20-%20Gender%20Inclusive%20Language%20in%20Research%20081519.pdf)
[Wikipedia Gender identity](https://en.wikipedia.org/wiki/Gender_identity)